### PR TITLE
Corrected Account Access Type Options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "aws_grafana_workspace" "this" {
   permission_type          = var.permission_type
   role_arn                 = aws_iam_role.this[0].arn
   data_sources             = var.data_sources
+  organizational_units     = var.organizational_units
 
   dynamic "vpc_configuration" {
     for_each = var.vpc_configuration != null ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -49,10 +49,16 @@ variable "data_sources" {
 
 variable "account_access_type" {
   type        = string
-  description = "The account access type for the workspace. Valid values are `CURRENT_ACCOUNT` or `ORGANIZATION`"
+  description = "The type of account access for the workspace. Valid values are CURRENT_ACCOUNT and ORGANIZATION. If ORGANIZATION is specified, then organizational_units must also be present."
   default     = "CURRENT_ACCOUNT"
   validation {
     condition     = contains(["CURRENT_ACCOUNT", "ORGANIZATION"], var.account_access_type)
     error_message = "account_access_type must be either CURRENT_ACCOUNT or ORGANIZATION"
   }
+}
+
+variable "organizational_units" {
+  type        = list(string)
+  description = "A list of organizational units (OU) IDs to grant access to the workspace. Only used if `var.account_access_type` is `ORGANIZATION`"
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,10 @@ variable "data_sources" {
 
 variable "account_access_type" {
   type        = string
-  description = "The account access type for the workspace. Valid values are `CURRENT_ACCOUNT` or `ALL_ACCOUNTS`"
+  description = "The account access type for the workspace. Valid values are `CURRENT_ACCOUNT` or `ORGANIZATION`"
   default     = "CURRENT_ACCOUNT"
+  validation {
+    condition     = contains(["CURRENT_ACCOUNT", "ORGANIZATION"], var.account_access_type)
+    error_message = "account_access_type must be either CURRENT_ACCOUNT or ORGANIZATION"
+  }
 }


### PR DESCRIPTION
## what
- Corrected comment for access access types
- Added validation

## why
- The correction options are `CURRENT_ACCOUNT` or `ORGANIZATION`, not `ALL_ACCOUNTS`

## references
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#account_access_type-1
