### PR TITLE
feat: expose configuration and grafana_version arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ resource "aws_grafana_workspace" "this" {
   role_arn                 = aws_iam_role.this[0].arn
   data_sources             = var.data_sources
   organizational_units     = var.organizational_units
+  configuration            = var.configuration
+  grafana_version          = var.grafana_version
 
   dynamic "vpc_configuration" {
     for_each = var.vpc_configuration != null ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,15 @@ variable "organizational_units" {
   description = "A list of organizational units (OU) IDs to grant access to the workspace. Only used if `var.account_access_type` is `ORGANIZATION`"
   default     = []
 }
+
+variable "configuration" {
+  type        = string
+  description = "JSON string containing the workspace configuration. Use this to enable Grafana unified alerting (`{\"unifiedAlerting\":{\"enabled\":true}}`) and/or plugin management (`{\"plugins\":{\"pluginAdminEnabled\":true}}`). See https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html"
+  default     = null
+}
+
+variable "grafana_version" {
+  type        = string
+  description = "The version of Grafana to support in the workspace. Supported values include `9.4`, `10.4`, `12.4`. If not specified, AMG defaults to the latest supported version."
+  default     = null
+}


### PR DESCRIPTION
## what

Plumb the `configuration` (JSON string) and `grafana_version` arguments of the underlying `aws_grafana_workspace` resource through this module. Both default to `null`, so behaviour is unchanged for existing callers.

## why

The `aws_grafana_workspace` resource has supported these arguments for a while ([docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#workspace-configuration-options)), but neither was reachable through this wrapper module. They are needed to:

1. **Enable Grafana unified alerting** on a workspace permanently. Workspaces created before AMG's unified-alerting cutover (or before AMG enabled it by default in the relevant region) run in legacy alerting mode; setting `configuration = jsonencode({unifiedAlerting = { enabled = true }})` is the one-way migration. Without this, alert rules / contact points / notification policies created via the unified-alerting API exist but are never evaluated.
2. **Pin the Grafana version** to one of AMG's supported majors (`9.4`, `10.4`, `12.4`) instead of always tracking the latest default. Some rollouts want predictable upgrades.

## example usage

```hcl
module "grafana" {
  source  = "cloudposse/managed-grafana/aws"

  configuration = jsonencode({
    unifiedAlerting = { enabled = true }
    plugins         = { pluginAdminEnabled = false }
  })
  grafana_version = "10.4"

  # ... other args ...
}
```

## references

- [`aws_grafana_workspace` configuration options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#workspace-configuration-options)
- [AMG: Working in your Grafana workspace (configuration semantics)](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html)
- [AMG: Alerts in Grafana version 10 (legacy → unified migration)](https://docs.aws.amazon.com/grafana/latest/userguide/v10-alerts.html)